### PR TITLE
Serialize sparse vectors as bytes field and use the protobuf classes directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tradeshift</groupId>
     <artifactId>blayze</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/kotlin/com/tradeshift/blayze/Model.kt
+++ b/src/main/kotlin/com/tradeshift/blayze/Model.kt
@@ -65,7 +65,7 @@ class Model(
     }
     companion object {
 
-        private val version = 2
+        private const val version = 3
 
         fun fromProto(proto: Protos.Model): Model {
             if (proto.modelVersion != version) {

--- a/src/main/kotlin/com/tradeshift/blayze/collection/SparseIntVector.kt
+++ b/src/main/kotlin/com/tradeshift/blayze/collection/SparseIntVector.kt
@@ -1,8 +1,9 @@
 package com.tradeshift.blayze.collection
 
+import com.google.protobuf.ByteString
 import com.tradeshift.blayze.Protos
+import java.nio.ByteBuffer
 import java.util.TreeMap
-
 
 /**
  * A sparse vector that stores non-zero indices and values in primitive arrays.
@@ -23,15 +24,30 @@ class SparseIntVector private constructor(private val indices: IntArray, private
     override fun iterator(): Iterator<Pair<Int, Int>> = indices.zip(values).iterator()
 
     fun toProto(): Protos.SparseIntVector = Protos.SparseIntVector.newBuilder()
-            .addAllIndices(indices.asIterable()).addAllValues(values.asIterable()).build()
+            .setIndices(toByteString(indices)).setValues(toByteString(values)).build()
+
 
     companion object {
+
+        private fun toIntArray(bytes: ByteString): IntArray {
+            val buffer = bytes.asReadOnlyByteBuffer().asIntBuffer()
+            val arr = IntArray(buffer.remaining())
+            buffer.get(arr)
+            return arr
+        }
+
+        private fun toByteString(ints: IntArray): ByteString {
+            val bb = ByteBuffer.allocate(ints.size * Integer.BYTES)
+            bb.asIntBuffer().put(ints)
+            return ByteString.copyFrom(bb)
+        }
+
         fun fromMap(map: Map<Int, Int>): SparseIntVector {
             val sortedNonZeros = map.filter { it.value != 0 }.toSortedMap()
             return SparseIntVector(sortedNonZeros.keys.toIntArray(), sortedNonZeros.values.toIntArray())
         }
 
         fun fromProto(proto: Protos.SparseIntVector): SparseIntVector =
-                SparseIntVector(proto.indicesList.toIntArray(), proto.valuesList.toIntArray())
+                SparseIntVector(toIntArray(proto.indices), toIntArray(proto.values))
     }
 }

--- a/src/main/protobuf/proto-defs.proto
+++ b/src/main/protobuf/proto-defs.proto
@@ -37,8 +37,8 @@ message Multinomial {
 }
 
 message SparseIntVector {
-    repeated uint32 indices = 1;
-    repeated uint32 values = 2;
+    bytes indices = 3;
+    bytes values = 4;
 }
 
 message Inputs {

--- a/src/test/kotlin/com/tradeshift/blayze/collection/SparseIntVectorTest.kt
+++ b/src/test/kotlin/com/tradeshift/blayze/collection/SparseIntVectorTest.kt
@@ -1,5 +1,6 @@
 package com.tradeshift.blayze.collection
 
+import com.tradeshift.blayze.Protos
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -7,13 +8,14 @@ class SparseIntVectorTest {
     private val vector = SparseIntVector.fromMap(mapOf(
             3 to 30,
             2 to 20,
-            1 to 10,
+            1 to 1000,
             7 to 70
     ))
 
+    private val expected = listOf(1 to 1000, 2 to 20, 3 to 30, 7 to 70)
+
     @Test
     fun iterates_in_order() {
-        val expected = listOf(1 to 10, 2 to 20, 3 to 30, 7 to 70)
         assertEquals(expected, vector.toList())
     }
 
@@ -21,7 +23,14 @@ class SparseIntVectorTest {
     fun add() {
         val other = SparseIntVector.fromMap(mapOf(1 to 10, 4 to 40, 7 to 70))
 
-        val expected = listOf(1 to 20, 2 to 20, 3 to 30, 4 to 40, 7 to 140)
+        val expected = listOf(1 to 1010, 2 to 20, 3 to 30, 4 to 40, 7 to 140)
         assertEquals(expected, vector.add(other).toList())
+    }
+
+    @Test
+    fun test_serialization() {
+        val proto = Protos.SparseIntVector.parseFrom(vector.toProto().toByteArray())
+        val v = SparseIntVector.fromProto(proto)
+        assertEquals(v.toList(), vector.toList())
     }
 }


### PR DESCRIPTION
A problem when deserializing models is that parameters need to be kept in memory twice. Once in the blayze classes and once in the generated protobuf classes. 
The generated protobuf classes take much more memory since all the int parameters get boxed.

This changes the SparseIntVector to use bytes to encode the indices and values. It then accesses values out of those fields directly so no boxed values are stored and there is no duplication since the model is just using the protobuf generated class.

Downside is that the serialized format is not as portable.

There is some slowdown associated with the change as well in jmh benchmarks:
